### PR TITLE
Webpack 4 deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function PermissionsOutputPlugin(options) {
 }
 
 PermissionsOutputPlugin.prototype.apply = function (compiler) {
-  compiler.plugin('done', () => {
+  compiler.hooks.done.tap('WebpackPermissionsPlugin', () => {
     if (this.options.buildFolders) {
       for (const dir of this.options.buildFolders) {
         const dirs = FileHound.create()

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ PermissionsOutputPlugin.prototype.apply = function (compiler) {
     }
   }
 
-  const webpackTap = compiler.hooks && compiler.hooks.done && compiler.hooks.done.tap;
+  const webpackTap = compiler.hooks && compiler.hooks.done && compiler.hooks.done.tap.bind(compiler.hooks.done);
 
   if (webpackTap) {
     webpackTap('WebpackPermissionsPlugin', changeFilePermissions);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function PermissionsOutputPlugin(options) {
 }
 
 PermissionsOutputPlugin.prototype.apply = function (compiler) {
-  compiler.hooks.done.tap('WebpackPermissionsPlugin', () => {
+  const changeFilePermissions = () => {
     if (this.options.buildFolders) {
       for (const dir of this.options.buildFolders) {
         const dirs = FileHound.create()
@@ -31,7 +31,15 @@ PermissionsOutputPlugin.prototype.apply = function (compiler) {
         fs.chmodSync(file.path || file, file.fileMode || 755);
       }
     }
-  });
+  }
+
+  const webpackTap = compiler.hooks && compiler.hooks.done && compiler.hooks.done.tap;
+
+  if (webpackTap) {
+    webpackTap('WebpackPermissionsPlugin', changeFilePermissions);
+  } else {
+    compiler.plugin('done', changeFilePermissions);
+  }
 };
 
 module.exports = PermissionsOutputPlugin;


### PR DESCRIPTION
The plugin works out-of-the-box with Webpack 4 but due to some changes in the Webpack plugin system, it causes some deprecation warning like:

> DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

According to the [Webpack 4 migration guide for plugins/loaders](https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202):

> The `plugin` method on tapable objects is theoretically backward-compatible, but it causes a deprecation warning, so plugins should consider switching to tap instead.

This pull request changes the old `compiler.plugin` call to the new `compiler.hooks.done` syntax using `tap`. It also add a name to the function attached to the hook as it's now used by the `ProfilingPlugin`, `ProgressPlugin`, etc.