### PR TITLE
Fix default permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,12 +41,12 @@ PermissionsOutputPlugin.prototype.apply = function(compiler) {
           .findSync();
         for (const di of dirs) {
           if (fs.existsSync(di)) {
-            fs.chmodSync(di, dir.dirMode || 644);
+            fs.chmodSync(di, dir.dirMode || 0o644);
           }
         }
         for (const fi of files) {
           if (fs.existsSync(fi)) {
-            fs.chmodSync(fi, dir.fileMode || 755);
+            fs.chmodSync(fi, dir.fileMode || 0o755);
           }
         }
       }
@@ -54,7 +54,7 @@ PermissionsOutputPlugin.prototype.apply = function(compiler) {
     if (this.options.buildFiles) {
       for (const file of this.options.buildFiles) {
         if (fs.existsSync(file.path || file)) {
-          fs.chmodSync(file.path || file, file.fileMode || 755);
+          fs.chmodSync(file.path || file, file.fileMode || 0o755);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-permissions-plugin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "George Kormaris <npm@gekorm.com>",
   "description": "A webpack plugin to set permissions for your output files and folders",
   "homepage": "https://github.com/GeKorm/webpack-permissions-plugin",


### PR DESCRIPTION
`chmodSync` expects mode to be passed as a string or as an integer octal (e.g. `0o755` instead of `755`).  This patch fixes the default permissions to match the documentation.