### PR TITLE
Fixing file selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,6 @@ PermissionsOutputPlugin.prototype.apply = function(compiler) {
           .findSync();
         const files = FileHound.create()
           .path(path)
-          .not()
-          .directory()
           .findSync();
         for (const di of dirs) {
           if (fs.existsSync(di)) {


### PR DESCRIPTION
Maybe it's because of change in Filehound, I don't know... but if with _.not().directory()_, no files are found for me...
when I remove it, it works as I expected...

also in documentation (https://nspragg.github.io/filehound/FileHound.html) it returns files by default, so explicitly saying "not directory" seems not needed anyway...

btw, I am using:
Node.js v14.15.4
npm 6.14.10
Filehound 1.17.4